### PR TITLE
Changes to allow output to be a gzip file #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ IBM Mainframe files on any workstation or laptop etc. that supports Java.
 
 ## Updates ##
 
+**Version 5.0.1: March 2024**
+
+- Added support to decompress then recompress into a gzip file if output-file name ends in ".gz"
+- Updated pom.xml to have Maven compile using Java 17, and shade the jar.
+
 **Version 5: March 2021**
 
 - Support for variable length binary records. Variable length records processed in binary mode will be prefixed with a 4 byte field in the same format as the IBM RDW i.e. 2 byte record length field (including RDW length, big-endian) followed by 2 bytes of zeros.
@@ -25,7 +30,7 @@ For execution, TerseDecompress needs a JVM runtime environment.
 
 Usage:
 
-```java -jar tersedecompress-5.0.0.jar [-b] tersed-file output-file```
+```java -jar tersedecompress-5.0.1.jar [-b] tersed-file output-file```
 
 Default mode is text mode, which will attempt EBCDIC -> ASCII conversion.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ IBM Mainframe files on any workstation or laptop etc. that supports Java.
 
 ## Updates ##
 
-**Version 5.0.1: March 2024**
+**Version 6: March 2024**
 
 - Added support to decompress then recompress into a gzip file if output-file name ends in ".gz"
 - Updated pom.xml to have Maven compile using Java 17, and shade the jar.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For execution, TerseDecompress needs a JVM runtime environment.
 
 Usage:
 
-```java -jar tersedecompress-5.0.1.jar [-b] tersed-file output-file```
+```java -jar tersedecompress-6.0.0.jar [-b] tersed-file output-file```
 
 Default mode is text mode, which will attempt EBCDIC -> ASCII conversion.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ IBM Mainframe files on any workstation or laptop etc. that supports Java.
 
 ## Updates ##
 
-**Version 6: March 2024**
+**Version 5.0.1: March 2024**
 
 - Added support to decompress then recompress into a gzip file if output-file name ends in ".gz"
 - Updated pom.xml to have Maven compile using Java 17, and shade the jar.
@@ -30,7 +30,7 @@ For execution, TerseDecompress needs a JVM runtime environment.
 
 Usage:
 
-```java -jar tersedecompress-6.0.0.jar [-b] tersed-file output-file```
+```java -jar tersedecompress-5.0.1.jar [-b] tersed-file output-file```
 
 Default mode is text mode, which will attempt EBCDIC -> ASCII conversion.
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.openmainframeproject.tersedecompress</groupId>
 	<artifactId>tersedecompress</artifactId>
-	<version>6.0.0</version>
+	<version>5.0.1</version>
 	<packaging>jar</packaging>
 
 	<name>tersedecompress</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.openmainframeproject.tersedecompress</groupId>
 	<artifactId>tersedecompress</artifactId>
-	<version>5.0.1</version>
+	<version>6.0.0</version>
 	<packaging>jar</packaging>
 
 	<name>tersedecompress</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.openmainframeproject.tersedecompress</groupId>
 	<artifactId>tersedecompress</artifactId>
-	<version>5.0.0</version>
+	<version>5.0.1</version>
 	<packaging>jar</packaging>
 
 	<name>tersedecompress</name>
@@ -13,6 +13,10 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jdk-release>17</jdk-release>
+		<junit-version>4.13.1</junit-version>
+        <maven-compiler-version>3.12.1</maven-compiler-version>
+        <maven-shade-version>3.5.1</maven-shade-version>
 		<skipTests>true</skipTests>	
 	</properties>
 	<build>
@@ -20,24 +24,47 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+				<version>${maven-compiler-version}</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<release>${jdk-release}</release>
 				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.2.0</version>
-				<configuration>
-					<archive>
-						<manifest>
-							<addClasspath>true</addClasspath>
-							<mainClass>org.openmainframeproject.tersedecompress.TerseDecompress</mainClass>
-						</manifest>
-					</archive>
-				</configuration>
+				<artifactId>maven-shade-plugin</artifactId>
+                <version>${maven-shade-version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <minimizeJar>true</minimizeJar>
+                            <entryPoints>
+                                <entryPoint>org.openmainframeproject.tersedecompress.TerseDecompress</entryPoint>
+                            </entryPoints>
+                            <transformers>
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Main-Class>org.openmainframeproject.tersedecompress.TerseDecompress</Main-Class>
+                                    </manifestEntries>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
 			</plugin>
 		</plugins>
 	</build>
@@ -45,7 +72,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<version>${junit-version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/org/openmainframeproject/tersedecompress/TerseDecompress.java
+++ b/src/main/java/org/openmainframeproject/tersedecompress/TerseDecompress.java
@@ -34,8 +34,12 @@ package org.openmainframeproject.tersedecompress;
 /*          Andrew Rowley, Black Hill Software                               */
 /*          Mario Bezzi, Watson Walker                                       */
 /*****************************************************************************/
+/* Version 6: support for gzipped output records                             */
+/*          Russell Shaw                                                     */
+/*****************************************************************************/
 
 import java.io.*;
+import java.util.zip.GZIPOutputStream;
 
 class TerseDecompress {
 
@@ -46,7 +50,7 @@ class TerseDecompress {
            +"The -b flag turns on binary mode, no conversion will be attempted\n"
           );
 
-    private static final String Version = new String ("Version 5, March 2021");
+    private static final String Version = new String ("Version 6, March 2024");
 	
 	private void printUsageAndExit() {
 		System.out.println(DetailedHelp);
@@ -95,14 +99,17 @@ class TerseDecompress {
     		printUsageAndExit();
     	}
 
+		TerseDecompresser outputWriter = null;
+		FileOutputStream fileOutputStream = new FileOutputStream(outputFileName);
 
-        try (TerseDecompresser outputWriter 
-        		= TerseDecompresser.create(new FileInputStream(inputFileName), new FileOutputStream(outputFileName)))
-        {	 
-        	outputWriter.TextFlag = textMode;
-	        System.out.println("Attempting to decompress input file (" + inputFileName +") to output file (" + outputFileName +")");
-	        outputWriter.decode();
-        }	
+		if (outputFileName.endsWith(".gz"))
+			outputWriter = TerseDecompresser.create(new FileInputStream(inputFileName), new GZIPOutputStream(fileOutputStream));
+		else
+			outputWriter = TerseDecompresser.create(new FileInputStream(inputFileName), fileOutputStream);
+
+       	outputWriter.TextFlag = textMode;
+	    System.out.println("Attempting to decompress input file (" + inputFileName +") to output file (" + outputFileName +")");
+	    outputWriter.decode();
 		
         System.out.println("Processing completed");
     }

--- a/src/main/java/org/openmainframeproject/tersedecompress/TerseDecompress.java
+++ b/src/main/java/org/openmainframeproject/tersedecompress/TerseDecompress.java
@@ -99,18 +99,23 @@ class TerseDecompress {
     		printUsageAndExit();
     	}
 
-		TerseDecompresser outputWriter = null;
-		FileOutputStream fileOutputStream = new FileOutputStream(outputFileName);
+		System.out.println("Attempting to decompress input file (" + inputFileName +") to output file (" + outputFileName +")");
 
-		if (outputFileName.endsWith(".gz"))
-			outputWriter = TerseDecompresser.create(new FileInputStream(inputFileName), new GZIPOutputStream(fileOutputStream));
-		else
-			outputWriter = TerseDecompresser.create(new FileInputStream(inputFileName), fileOutputStream);
+		if (outputFileName.endsWith(".gz")) {
+			try (TerseDecompresser outputWriter = TerseDecompresser.create(new FileInputStream(inputFileName), new GZIPOutputStream(new FileOutputStream(outputFileName), 8192, true)))
+			{	 
+				outputWriter.TextFlag = textMode;
+				outputWriter.decode();
+			}
+		}
+		else {
+			try (TerseDecompresser outputWriter = TerseDecompresser.create(new FileInputStream(inputFileName), new FileOutputStream(outputFileName)))
+			{	 
+				outputWriter.TextFlag = textMode;
+				outputWriter.decode();
+			}
+		}
 
-       	outputWriter.TextFlag = textMode;
-	    System.out.println("Attempting to decompress input file (" + inputFileName +") to output file (" + outputFileName +")");
-	    outputWriter.decode();
-		
         System.out.println("Processing completed");
     }
 


### PR DESCRIPTION
You cn now specify that you want the output to be gzip file, by specifying an output filename with suffix of ".gz"
eg java -jar tersedecompress-5.0.1.jar -b smfdata.trs smfdata.gz