### PR TITLE
feat: add code quality tooling (compiler warnings + static analysis) #28

### DIFF
--- a/QUALITY.md
+++ b/QUALITY.md
@@ -1,0 +1,113 @@
+# Code Quality
+
+This document describes the compiler warnings and static analysis tools enabled in
+TerseDecompress.  All quality tooling is **best-effort** — findings are reported but
+do not automatically block the build or the merge of a PR.
+
+---
+
+## Compiler Warnings
+
+### Java
+
+Java compiler lint warnings are enabled via the `-Xlint:all` flag in
+[`pom.xml`](pom.xml).  The flag is passed through `maven-compiler-plugin`'s
+`compilerArgs` section and applies to every `mvn compile` or `mvn package`
+invocation.
+
+The build **will not fail** on warnings; they are surfaced as informational
+messages in the Maven output.
+
+### C++
+
+Sane diagnostic flags are enabled in [`cpp/envdef.mak`](cpp/envdef.mak):
+
+| Flag | Purpose |
+|------|---------|
+| `-Wall` | Enable commonly-used warnings |
+| `-Wextra` | Enable extra warnings not covered by `-Wall` |
+| `-Wpedantic` | Enforce strict ISO C++ conformance |
+
+These flags apply to both the Linux/macOS (`clang++`) and IBM z/OS
+(`ibm-clang++`) toolchains.  Warnings are **not** treated as errors
+(`-Werror` is intentionally omitted).
+
+---
+
+## Static Analysis
+
+### Java — SpotBugs
+
+[SpotBugs](https://spotbugs.github.io/) is configured as a Maven plugin in
+[`pom.xml`](pom.xml).
+
+**Run locally:**
+
+```bash
+mvn spotbugs:check
+```
+
+Or to open the interactive GUI report:
+
+```bash
+mvn spotbugs:gui
+```
+
+SpotBugs is configured with:
+
+| Setting | Value | Reason |
+|---------|-------|--------|
+| `failOnError` | `false` | Best-effort; never breaks the build |
+| `effort` | `Max` | Most thorough analysis |
+| `threshold` | `Low` | Surface all potential findings |
+| `noClassOk` | `true` | Skip unresolvable JDK references gracefully |
+
+### C++ — cppcheck
+
+[cppcheck](https://cppcheck.sourceforge.io/) is invoked via the `lint` target
+in [`cpp/Makefile`](cpp/Makefile).
+
+**Install cppcheck:**
+
+```bash
+# Debian / Ubuntu
+sudo apt-get install cppcheck
+
+# macOS (Homebrew)
+brew install cppcheck
+
+# Windows (Chocolatey)
+choco install cppcheck
+```
+
+**Run locally** (from the `cpp/` directory):
+
+```bash
+make lint
+```
+
+This runs:
+
+```bash
+cppcheck --enable=all --std=c++17 --suppress=missingIncludeSystem src/
+```
+
+| Option | Purpose |
+|--------|---------|
+| `--enable=all` | Enable style, performance, portability and unused-function checks |
+| `--std=c++17` | Match the project's C++ standard |
+| `--suppress=missingIncludeSystem` | Suppress noise from system headers that cppcheck cannot resolve |
+
+---
+
+## Best-Effort Statement
+
+The quality tooling described in this document is provided on a **best-effort**
+basis.  There is no SLA or guarantee that:
+
+- every warning will be fixed in a given timeframe,
+- the tools will run in all CI environments, or
+- a PR that introduces new warnings will be automatically rejected.
+
+Contributors are encouraged to check the output of these tools before
+submitting a PR and to address warnings where practical.

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -1,6 +1,6 @@
 .SECONDARY:
 .SUFIXES:
-.PHONY: all src tests clean
+.PHONY: all src tests clean lint
 
 UNAME:=$(shell uname)
 
@@ -22,3 +22,8 @@ all: src
 clean:
 	$(MAKE) $(MAKE_FLAGS) -C src clean
 	$(MAKE) $(MAKE_FLAGS) -C tests clean
+
+lint:
+	cppcheck --enable=all --std=c++17 \
+	         --suppress=missingIncludeSystem \
+	         src/

--- a/cpp/envdef.mak
+++ b/cpp/envdef.mak
@@ -4,7 +4,7 @@ BIN_DIR:=$(ROOT_DIR)bin
 
 UNAME:=$(shell uname)
 PREFIX?=$(HOME)/local
-CXXFLAGS = -std=c++17 -O2
+CXXFLAGS = -std=c++17 -O2 -Wall -Wextra -Wpedantic
 CCFLAGS_DLL += -fPIC -fvisibility=default
 AR=ar
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,9 @@
 				<version>3.11.0</version>
 				<configuration>
                     <release>21</release>
+					<compilerArgs>
+						<arg>-Xlint:all</arg>
+					</compilerArgs>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -69,6 +72,20 @@
 						<phase>generate-sources</phase>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<version>4.9.3.1</version>
+				<configuration>
+					<!-- Best-effort: report findings but never fail the build -->
+					<failOnError>false</failOnError>
+					<effort>Max</effort>
+					<threshold>Low</threshold>
+					<!-- Analyse only project classes; skip unresolvable JDK references -->
+					<noClassOk>true</noClassOk>
+					<jvmArgs>-Dfindbugs.ignoreUnresolvable=true</jvmArgs>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
## Summary

Closes #28

Addresses all three OpenSSF Best Practices quality-related recommendations:
compiler warnings, static analysis, and documentation.

---

## What changed and why

### `pom.xml` — Java compiler warnings + SpotBugs

**Compiler warnings:**  
Added `-Xlint:all` to `maven-compiler-plugin`'s `<compilerArgs>`. This surfaces
all Java lint diagnostics on every `mvn compile` / `mvn package` run without
failing the build (`-Werror` is intentionally not used).

**Static analysis:**  
Added the [SpotBugs](https://spotbugs.github.io/) Maven plugin (`v4.9.3.1`).
Configured as best-effort so it never blocks the build:

| Setting | Value | Reason |
|---------|-------|--------|
| `failOnError` | `false` | Reports findings without blocking CI or local builds |
| `effort` | `Max` | Most thorough bytecode analysis |
| `threshold` | `Low` | Surface all potential findings, not just high-severity |
| `noClassOk` | `true` | Gracefully handles unresolvable JDK references |

Run locally:
```bash
mvn spotbugs:check   # prints findings to console
mvn spotbugs:gui     # opens interactive GUI report
